### PR TITLE
Add screen command for virtual screening

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ cd boltz; pip install -e .
 You can run inference using Boltz with:
 
 ```
-boltz predict input_path --use_msa_server
+boltz predict input_path
 ```
+
+Boltz will automatically generate MSAs using the MMSeqs2 server. Disable this by passing `--no-use_msa_server`.
 
 `input_path` should point to a YAML file, or a directory of YAML files for batched processing, describing the biomolecules you want to model and the properties you want to predict (e.g. affinity). To see all available options: `boltz predict --help` and for more information on these input formats, see our [prediction instructions](docs/prediction.md). By default, the `boltz` command will run the latest version of the model.
 
@@ -49,14 +51,16 @@ boltz predict input_path --use_msa_server
 There are two main predictions in the affinity output: `affinity_pred_value` and `affinity_probability_binary`. They are trained on largely different datasets, with different supervisions, and should be used in different contexts. The `affinity_probability_binary` field should be used to detect binders from decoys, for example in a hit-discovery stage. It's value ranges from 0 to 1 and represents the predicted probability that the ligand is a binder. The `affinity_pred_value` aims to measure the specific affinity of different binders and how this changes with small modifications of the molecule. This should be used in ligand optimization stages such as hit-to-lead and lead-optimization. It reports a binding affinity value as `log(IC50)`, derived from an `IC50` measured in `μM`. More details on how to run affinity predictions and parse the output can be found in our [prediction instructions](docs/prediction.md).
 
 
-## Evaluation
 
-⚠️ **Coming soon: updated evaluation code for Boltz-2!**
+## Virtual Screening
 
-To encourage reproducibility and facilitate comparison with other models, on top of the existing Boltz-1 evaluation pipeline, we will soon provide the evaluation scripts and structural predictions for Boltz-2, Boltz-1, Chai-1 and AlphaFold3 on our test benchmark dataset, and our affinity predictions on the FEP+ benchamark, CASP16 and our MF-PCBA test set.
+Run high throughput affinity predictions from a CSV description with:
 
-![Affinity test sets evaluations](docs/pearson_plot.png)
-![Test set evaluations](docs/plot_test_boltz2.png)
+```
+boltz screen inputs.csv --inference-device 0,1 -o output_dir
+```
+
+Each row in `inputs.csv` must contain `complex_name`, `protein_path` or `protein_sequence`, and `ligand_description`. Duplicate protein sequences are processed only once and reused across ligands. Results are written to `screening_results.csv` in the output directory.
 
 
 ## Training

--- a/examples/screen.csv
+++ b/examples/screen.csv
@@ -1,0 +1,3 @@
+complex_name,protein_path,protein_sequence,ligand_description
+example_from_yaml,examples/prot.yaml,,CC(=O)OC1=CC=CC=C1C(=O)O
+example_from_sequence,,QLEDSEVEAVAKGLEEMYANGVTEDNFKNYVKNNFAQQEISSVEEELNVNISDSCVANKIKDEFFAMISISAIVKAAQKKAWKELAVTVLRFAKANGLKTNAIIVAGQLALWAVQCG,N[C@@H](Cc1ccc(O)cc1)C(=O)O


### PR DESCRIPTION
## Summary
- implement `screen` CLI for CSV-based virtual screening
- cache MSAs across repeated complexes and default to using the MSA server
- document virtual screening and default MSA behaviour
- remove evaluation section from README
- add example CSV for screening in `examples`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytorch_lightning')*

------
https://chatgpt.com/codex/tasks/task_b_685089c0eb788320bb9972b86e15cd1b